### PR TITLE
Make slider simpler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 /package
 google-credentials.json
 /doc/storybook-static
+/doc/out*

--- a/README.md
+++ b/README.md
@@ -187,7 +187,30 @@ This can then be rendered as:
 
 ### `Slider`
 
-To do
+`Slider` renders a single component at a time and provides the necessary functionality to navigate back and forth through swipe gestures (on touch devices) or mouse clicks (on desktop). Check out its [stories](https://rbb-data.github.io/svelte-starter/?path=/story/core-slider--basic).
+
+`Slider` keeps track of the active slide internally. Binding to this prop is a common pattern. For example:
+
+```svelte
+<script>
+  import Slide from './Slide.svelte';
+
+  // a list of slide components
+  const slides = [..., { component: Slide, props: { ... } }, ...];
+
+  // the active index
+  let activeIndex;
+</script>
+
+<Slider
+  {slides}
+  prev={(idx) => (idx - 1 >= 0 ? idx - 1 : null)}
+  next={(idx) => (idx + 1 <= nSlides - 1 ? idx + 1 : null)}
+  bind:activeIndex
+/>
+```
+
+`prev` and `next` determine the index of the previous and next slide; returning `null` means there is no slide to go to.
 
 ### `Svg`
 

--- a/doc/src/helpers/Slide.svelte
+++ b/doc/src/helpers/Slide.svelte
@@ -1,11 +1,11 @@
 <script>
   import { css } from '@rbb-data/svelte-starter/actions';
 
-  export let message;
+  export let content;
   export let color;
 </script>
 
-<div use:css={{ color }}>{message}</div>
+<div use:css={{ color }}>{content}</div>
 
 <style>
   div {

--- a/doc/src/stories/Slider.stories.svelte
+++ b/doc/src/stories/Slider.stories.svelte
@@ -1,11 +1,11 @@
 <script>
-  import { Meta, Story } from '@storybook/addon-svelte-csf';
+  import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
   import { Slider } from '@rbb-data/svelte-starter';
   import Slide from '../helpers/Slide.svelte';
 
   const colors = ['aliceblue', 'lavender'];
 
-  const allSlides = [
+  const slideContent = [
     'Slide #1',
     'Slide #2',
     'Slide #3',
@@ -13,35 +13,16 @@
     'Slide #5',
     'Slide #6',
   ];
-  let currIdx = 0;
 
-  const prev = (idx, carousel = false) =>
-    idx - 1 >= 0 ? idx - 1 : carousel ? allSlides.length - 1 : null;
-  const next = (idx, carousel = false) =>
-    idx + 1 <= allSlides.length - 1 ? idx + 1 : carousel ? 0 : null;
+  const nSlides = slideContent.length;
 
-  function constructSlide(idx) {
-    if (idx === null) return null;
-    return {
-      component: Slide,
-      props: {
-        message: allSlides[idx],
-        color: colors[idx % 2],
-      },
-    };
-  }
-
-  $: slides = [
-    constructSlide(prev(currIdx)),
-    constructSlide(currIdx),
-    constructSlide(next(currIdx)),
-  ];
-
-  $: carouselSlides = [
-    constructSlide(prev(currIdx, true)),
-    constructSlide(currIdx),
-    constructSlide(next(currIdx, true)),
-  ];
+  $: slides = slideContent.map((content, i) => ({
+    component: Slide,
+    props: {
+      content,
+      color: colors[i % 2],
+    },
+  }));
 </script>
 
 <Meta
@@ -57,37 +38,52 @@
         },
       },
     },
-    onForwardNavigation: {
-      name: 'onForwardNavigation',
+    prev: {
+      name: 'prev',
+      control: null,
       table: {
         type: {
-          summary: '() => void',
+          summary: '(activeIndex: number) => number',
         },
       },
     },
-    onBackwardNavigation: {
-      name: 'onBackwardNavigation',
+    next: {
+      name: 'next',
+      control: null,
       table: {
         type: {
-          summary: '() => void',
+          summary: '(activeIndex: number) => number',
+        },
+      },
+    },
+    activeIndex: {
+      name: 'activeIndex',
+      type: { name: 'number' },
+      table: {
+        type: {
+          summary: 'number',
         },
       },
     },
   }}
 />
 
-<Story name="Basic">
-  <Slider
-    {slides}
-    onBackwardNavigation={() => (currIdx = prev(currIdx))}
-    onForwardNavigation={() => (currIdx = next(currIdx))}
-  />
-</Story>
+<Template let:args>
+  <Slider {slides} {...args} />
+</Template>
 
-<Story name="Carousel">
-  <Slider
-    slides={carouselSlides}
-    onBackwardNavigation={() => (currIdx = prev(currIdx, true))}
-    onForwardNavigation={() => (currIdx = next(currIdx, true))}
-  />
-</Story>
+<Story
+  name="Basic"
+  args={{
+    prev: (idx) => (idx - 1 >= 0 ? idx - 1 : null),
+    next: (idx) => (idx + 1 <= nSlides - 1 ? idx + 1 : null),
+  }}
+/>
+
+<Story
+  name="Carousel"
+  args={{
+    prev: (idx) => (idx - 1 >= 0 ? idx - 1 : nSlides - 1),
+    next: (idx) => (idx + 1 <= nSlides - 1 ? idx + 1 : 0),
+  }}
+/>

--- a/src/lib/components/core/Slider.svelte
+++ b/src/lib/components/core/Slider.svelte
@@ -6,16 +6,26 @@
   import css from '$lib/actions/css';
   import pannable, { drag } from '$lib/actions/pannable';
 
-  // array of three slides: the previous, the current, and the next
+  // list of slides
   export let slides: Array<Component>;
 
-  // function called on forward navigation
-  export let onForwardNavigation: () => void;
+  // function that determines the previous slide
+  export let prev: (index: number) => number | null;
 
-  // function called on backward navigation
-  export let onBackwardNavigation: () => void;
+  // function that determines the next slide
+  export let next: (index: number) => number | null;
 
-  $: [prevSlide, currSlide, nextSlide] = slides;
+  // intial slide index
+  export let initialActiveIndex = 0;
+
+  // index of the currently visible slide
+  export let activeIndex = initialActiveIndex;
+
+  $: currSlide = slides[activeIndex];
+
+  $: prevSlide = prev(activeIndex) !== null ? slides[prev(activeIndex)] : null;
+  $: nextSlide = next(activeIndex) !== null ? slides[next(activeIndex)] : null;
+
   $: prevNext = [prevSlide, nextSlide]
     .map((slide, i) => ({ slide, key: i === 0 ? 'prev' : 'next' }))
     .filter(({ slide }) => slide);
@@ -54,8 +64,8 @@
     setTimeout(() => {
       animate = false;
       xy.set({ x: 0, y: 0 });
-      if (navigateBackward) onBackwardNavigation();
-      else onForwardNavigation();
+      if (navigateBackward) activeIndex = prev(activeIndex);
+      else activeIndex = next(activeIndex);
     }, 500);
   }
 


### PR DESCRIPTION
Previously, `Slider` only consumed the previous, current and next slide. This put a lot of work on the user. The API has been simplified.