### PR TITLE
Add custom iframe resizer script

### DIFF
--- a/iframe.html
+++ b/iframe.html
@@ -6,29 +6,24 @@
   sized properly. If you don't want this, simply remove the script tags.
 -->
 
-<iframe
-  title="To do: Insert title"
-  loading="lazy"
-  width="100%"
-  height="600"
-  id="rbb-data--{project-name}"
-  src="https://www.rbb-online.de/static/rbb/rbb-data/{project-name}/"
-></iframe>
 <style>
   /* explained here: https://github.com/davidjbradshaw/iframe-resizer#typical-setup */
   #rbb-data--{project-name} {
     width: 1px;
     min-width: 100%;
-  }
-  /* fix position in app */
-  @media screen and (max-width: 630px) {
-    #rbb-data--{project-name} {
-      width: 100%; /* full width in app */
-      margin-left: 0; /* center in app */
-    }
+    border: 0;
   }
 </style>
-<script src="https://storage.googleapis.com/rbb-data-static/iframe-resizer/iframeResizer.min.js"></script>
+<iframe
+  id="rbb-data--{project-name}"
+  src="https://storage.googleapis.com/rbb-data-static/{project-name}/index.html"
+  title="IMPORTANT: ADD TITLE"
+  loading="lazy"
+  width="100%"
+  scrolling="no"
+  frameborder="0"
+></iframe>
+<script src="https://storage.googleapis.com/rbb-data-static/lib/iframe-resizer/iframe-resizer.js"></script>
 <script>
-  iFrameResize({}, '#rbb-data--{project-name}');
+  rbbData.resizeIframe('rbb-data--{project-name}');
 </script>

--- a/src/app.html
+++ b/src/app.html
@@ -5,10 +5,13 @@
     <link rel="icon" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     %svelte.head%
+    <!-- both needed for the iframe resizer script below -->
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=ResizeObserver"></script>
+    <script src="https://storage.googleapis.com/rbb-data-static/lib/lodash.throttle.js"></script>
   </head>
   <body>
     <div id="svelte">%svelte.body%</div>
-    <!-- iFrame resizer script -->
-    <script src="https://storage.googleapis.com/rbb-data-static/iframe-resizer/iframeResizer.contentWindow.min.js"></script>
+    <!-- iframe resizer script that notifies a parent window of changes to the body's height -->
+    <script src="https://storage.googleapis.com/rbb-data-static/lib/iframe-resizer/iframe-resizer.notify.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Scripts from https://github.com/davidjbradshaw/iframe-resizer work perfectly well, but - sadly - lead to issues within the app. I have no way of debugging why that is, so I wrote a minimal reproduction of these resizer scripts that do work in the app. If app support is not needed, however, there is no reason to use this code, use https://github.com/davidjbradshaw/iframe-resizer instead, which is well maintained and heavily tested.

Resizer scripts live here: https://github.com/rbb-data/iframe-sizer-script

Relates to #39